### PR TITLE
stemcell_builder: Include google_gcscli in agent stages

### DIFF
--- a/bosh-stemcell/lib/bosh/stemcell/stage_collection.rb
+++ b/bosh-stemcell/lib/bosh/stemcell/stage_collection.rb
@@ -34,6 +34,7 @@ module Bosh::Stemcell
         :bosh_libyaml,
         :bosh_go_agent,
         :aws_cli,
+        :google_gcscli,
         :logrotate_config,
         :dev_tools_config,
         :static_libraries_config,
@@ -141,7 +142,6 @@ module Bosh::Stemcell
 
     def google_stages
       [
-        :google_gcscli,
         :system_network,
         :system_google_modules,
         :system_google_packages,


### PR DESCRIPTION
Response to `let's include gcscli in all stemcells similar to
s3cli.` @cppforlife
https://github.com/cloudfoundry/bosh-linux-stemcell-builder/pull/16#pullrequestreview-53333669